### PR TITLE
Add --ads switch to scan alternate data streams for hidden prefetch

### DIFF
--- a/PECmd/Program.cs
+++ b/PECmd/Program.cs
@@ -1018,11 +1018,44 @@ internal class Program
 
 
 
-    private static CsvOut GetCsvFormat(IPrefetch pf, string dt)
+    //Prefetch parsed from an alternate data stream can come back with unset (MinValue) source
+    //timestamps on .NET Framework, which cannot stat a "host:stream" path (modern .NET resolves it
+    //to the host file and populates them). Recover them from the carrier (host) file, whose
+    //timestamps an alternate data stream inherits. No-op when the timestamps are already populated.
+    private static (DateTimeOffset created, DateTimeOffset modified, DateTimeOffset accessed) GetSourceTimestamps(IPrefetch pf)
     {
         var created = pf.SourceCreatedOn;
         var modified = pf.SourceModifiedOn;
         var accessed = pf.SourceAccessedOn;
+
+        var sourceName = pf.SourceFilename;
+
+        //Already populated, or not an alternate data stream path (a ':' after the drive letter)
+        if (created.Year > 1601 || sourceName.Length <= 2 || sourceName.IndexOf(':', 2) < 0)
+        {
+            return (created, modified, accessed);
+        }
+
+        var carrier = sourceName.Substring(0, sourceName.LastIndexOf(':'));
+
+        try
+        {
+            var fi = new FileInfo(carrier);
+            created = new DateTimeOffset(fi.CreationTimeUtc);
+            modified = new DateTimeOffset(fi.LastWriteTimeUtc);
+            accessed = new DateTimeOffset(fi.LastAccessTimeUtc);
+        }
+        catch (Exception e)
+        {
+            Log.Debug(e,"Could not read carrier file timestamps for {Carrier}. Error: {Message}",carrier,e.Message);
+        }
+
+        return (created, modified, accessed);
+    }
+
+    private static CsvOut GetCsvFormat(IPrefetch pf, string dt)
+    {
+        var (created, modified, accessed) = GetSourceTimestamps(pf);
 
         var volDate = string.Empty;
         var volName = string.Empty;
@@ -1176,9 +1209,7 @@ internal class Program
             }
 
 
-            var created = pf.SourceCreatedOn;
-            var modified = pf.SourceModifiedOn;
-            var accessed = pf.SourceAccessedOn;
+            var (created, modified, accessed) = GetSourceTimestamps(pf);
 
             Log.Information("Created on: {CreatedOn}",created);
             Log.Information("Modified on: {Modified}",modified);

--- a/PECmd/Program.cs
+++ b/PECmd/Program.cs
@@ -1422,8 +1422,12 @@ internal class Program
             return;
         }
 
+        var scanned = 0;
+        var foundBefore = _processedFiles.Count;
+
         foreach (var file in allFiles)
         {
+            scanned += 1;
             try
             {
                 ScanFileForAds(file, q);
@@ -1433,6 +1437,9 @@ internal class Program
                 Log.Debug(e,"Error scanning alternate data streams for {File}. Error: {Message}",file,e.Message);
             }
         }
+
+        Log.Information("Checked {Scanned:N0} files in {Dir}; found {Found:N0} prefetch file(s) hidden in alternate data streams",scanned,scanName,_processedFiles.Count - foundBefore);
+        Console.WriteLine();
     }
 
     private static void ScanFileForAds(string file, bool q)

--- a/PECmd/Program.cs
+++ b/PECmd/Program.cs
@@ -1512,6 +1512,7 @@ internal class Program
 
     private static IEnumerable<string> EnumerateAllFiles(string dir)
     {
+#if !NET9_0_OR_GREATER
         var filters = new Alphaleonis.Win32.Filesystem.DirectoryEnumerationFilters
         {
             InclusionFilter = _ => true,
@@ -1527,6 +1528,17 @@ internal class Program
             Alphaleonis.Win32.Filesystem.DirectoryEnumerationOptions.BasicSearch;
 
         return Alphaleonis.Win32.Filesystem.Directory.EnumerateFileSystemEntries(dir, options, filters);
+#else
+        var options = new EnumerationOptions
+        {
+            IgnoreInaccessible = true,
+            MatchCasing = MatchCasing.CaseInsensitive,
+            RecurseSubdirectories = true,
+            AttributesToSkip = 0
+        };
+
+        return Directory.EnumerateFiles(dir, "*", options);
+#endif
     }
 
     private static Stream OpenAdsStream(string streamFullPath)

--- a/PECmd/Program.cs
+++ b/PECmd/Program.cs
@@ -1159,6 +1159,14 @@ internal class Program
             csOut.Note = "File contains > 2 volumes! Please inspect output from main program for full details!";
         }
 
+        //Flag prefetch recovered from an alternate data stream (a ':' after the drive letter)
+        if (pf.SourceFilename.Length > 2 && pf.SourceFilename.IndexOf(':', 2) >= 0)
+        {
+            csOut.Note = csOut.Note.IsNullOrEmpty()
+                ? "Prefetch found in ADS"
+                : $"Prefetch found in ADS. {csOut.Note}";
+        }
+
         var sbDirs = new StringBuilder();
         if (pf.VolumeInformation != null)
         {

--- a/PECmd/Program.cs
+++ b/PECmd/Program.cs
@@ -168,8 +168,14 @@ internal class Program
             Description = "Deduplicate -f or -d & VSCs based on SHA-1. First file found wins",
             DefaultValueFactory = _ => false
         };
-        
-        
+
+        var adsOpt = new Option<bool>("--ads")
+        {
+            Description = "Scan alternate data streams of every file under -d (or the -f file) and parse any prefetch data found hidden in them",
+            DefaultValueFactory = _ => false
+        };
+
+
         var debugOpt = new Option<bool>("--debug")
         {
             Description = "Show debug information during processing",
@@ -197,16 +203,17 @@ internal class Program
           mpOpt,
           vssOpt,
           dedupeOpt,
+          adsOpt,
           debugOpt,
           traceOpt
-          
+
         };
 
         _rootCommand.Description = Header + "\r\n\r\n" + Footer;
 
         _rootCommand.SetAction(result => DoWork(result.GetValue(fOpt), result.GetValue(dOpt), result.GetValue(kOpt),
             result.GetValue(oOpt), result.GetValue(qOpt), result.GetValue(jsonOpt), result.GetValue(jsonfOpt),
-            result.GetValue(csvOpt),result.GetValue(csvfOpt),result.GetValue(htmlOpt),result.GetValue(dtOpt),result.GetValue(mpOpt),result.GetValue(vssOpt),result.GetValue(dedupeOpt),result.GetValue(debugOpt),result.GetValue(traceOpt)));
+            result.GetValue(csvOpt),result.GetValue(csvfOpt),result.GetValue(htmlOpt),result.GetValue(dtOpt),result.GetValue(mpOpt),result.GetValue(vssOpt),result.GetValue(dedupeOpt),result.GetValue(adsOpt),result.GetValue(debugOpt),result.GetValue(traceOpt)));
 
         var foo = _rootCommand.Parse(args).InvokeAsync();
         
@@ -214,7 +221,7 @@ internal class Program
     }
 
 
-    private static void DoWork(string f, string d, string k, string o, bool q, string json, string jsonf, string csv, string csvf, string html, string dt, bool mp, bool vss, bool dedupe, bool debug, bool trace)
+    private static void DoWork(string f, string d, string k, string o, bool q, string json, string jsonf, string csv, string csvf, string html, string dt, bool mp, bool vss, bool dedupe, bool ads, bool debug, bool trace)
     {
         var levelSwitch = new LoggingLevelSwitch();
 
@@ -392,6 +399,28 @@ internal class Program
                             if (pf != null)
                             {
                                 _processedFiles.Add(pf);
+                            }
+                        }
+                    }
+                }
+
+                if (ads)
+                {
+                    ScanFileForAds(f, q);
+
+                    if (vss)
+                    {
+                        var vssDirs = Directory.GetDirectories(VssDir);
+
+                        var root = Path.GetPathRoot(Path.GetFullPath(f));
+                        var stem = Path.GetFullPath(f).Replace(root, "");
+
+                        foreach (var vssDir in vssDirs)
+                        {
+                            var newPath = Path.Combine(vssDir, stem);
+                            if (File.Exists(newPath))
+                            {
+                                ScanFileForAds(newPath, q);
                             }
                         }
                     }
@@ -629,6 +658,27 @@ internal class Program
                 foreach (var failedFile in _failedFiles)
                 {
                     Log.Information("  {FailedFile}",failedFile);
+                }
+            }
+
+            if (ads)
+            {
+                Console.WriteLine();
+                ScanDirectoryForAds(d, q);
+
+                if (vss && Directory.Exists(VssDir))
+                {
+                    foreach (var vssDir in Directory.GetDirectories(VssDir))
+                    {
+                        var root = Path.GetPathRoot(Path.GetFullPath(d));
+                        var stem = Path.GetFullPath(d).Replace(root, "");
+                        var target = Path.Combine(vssDir, stem);
+
+                        if (Directory.Exists(target))
+                        {
+                            ScanDirectoryForAds(target, q);
+                        }
+                    }
                 }
             }
         }
@@ -1336,7 +1386,143 @@ internal class Program
         return null;
     }
 
-  
+    private static void ScanDirectoryForAds(string dir, bool q)
+    {
+        var scanName = dir;
+        if (dir.StartsWith(VssDir))
+        {
+            scanName = $"VSS{dir.Replace($"{VssDir}\\", "")}";
+        }
+
+        Log.Information("Scanning alternate data streams of all files in {Dir} for embedded prefetch data...",scanName);
+        Console.WriteLine();
+
+        IEnumerable<string> allFiles;
+
+        try
+        {
+            allFiles = EnumerateAllFiles(dir);
+        }
+        catch (Exception e)
+        {
+            Log.Error(e,"Unable to enumerate files in {Dir} for alternate data stream scanning. Error: {Message}",scanName,e.Message);
+            return;
+        }
+
+        foreach (var file in allFiles)
+        {
+            try
+            {
+                ScanFileForAds(file, q);
+            }
+            catch (Exception e)
+            {
+                Log.Debug(e,"Error scanning alternate data streams for {File}. Error: {Message}",file,e.Message);
+            }
+        }
+    }
+
+    private static void ScanFileForAds(string file, bool q)
+    {
+        foreach (var (streamFullPath, streamName) in GetAlternateDataStreams(file))
+        {
+            var sourceName = $"{file}:{streamName}";
+
+            //May already be processed by the built-in .pf ADS handling. Skip to avoid duplicate output
+            if (_processedFiles.Any(p =>
+                    string.Equals(p.SourceFilename, sourceName, StringComparison.OrdinalIgnoreCase)))
+            {
+                continue;
+            }
+
+            Stream s;
+
+            try
+            {
+                s = OpenAdsStream(streamFullPath);
+            }
+            catch (Exception e)
+            {
+                Log.Warning(e,"Unable to open alternate data stream {SourceName}. Error: {Message}",sourceName,e.Message);
+                continue;
+            }
+
+            using (s)
+            {
+                IPrefetch pf;
+
+                try
+                {
+                    pf = PrefetchFile.Open(s, sourceName);
+                }
+                catch (Exception e)
+                {
+                    //The stream is not a prefetch file. This is expected for the vast majority of streams
+                    //(Zone.Identifier and similar), so keep it quiet unless debugging
+                    Log.Debug(e,"Alternate data stream {SourceName} is not a prefetch file. Error: {Message}",sourceName,e.Message);
+                    continue;
+                }
+
+                Log.Information("Found prefetch data in alternate data stream: {SourceName}",sourceName);
+                Console.WriteLine();
+
+                if (q == false)
+                {
+                    DisplayFile(pf, q, ActiveDateTimeFormat);
+                }
+
+                _processedFiles.Add(pf);
+            }
+        }
+    }
+
+    private static List<(string fullPath, string name)> GetAlternateDataStreams(string file)
+    {
+        var result = new List<(string, string)>();
+
+        try
+        {
+            var fsi = new Alphaleonis.Win32.Filesystem.FileInfo(file);
+
+            foreach (var adsInfo in fsi.EnumerateAlternateDataStreams().Where(t => t.StreamName.Length > 0))
+            {
+                result.Add((adsInfo.FullPath, adsInfo.StreamName));
+            }
+        }
+        catch (Exception e)
+        {
+            Log.Debug(e,"Could not enumerate alternate data streams for {File}. Error: {Message}",file,e.Message);
+        }
+
+        return result;
+    }
+
+    private static IEnumerable<string> EnumerateAllFiles(string dir)
+    {
+        var filters = new Alphaleonis.Win32.Filesystem.DirectoryEnumerationFilters
+        {
+            InclusionFilter = _ => true,
+            RecursionFilter = entryInfo => !entryInfo.IsMountPoint && !entryInfo.IsSymbolicLink,
+            ErrorFilter = (errorCode, errorMessage, pathProcessed) => true
+        };
+
+        var options =
+            Alphaleonis.Win32.Filesystem.DirectoryEnumerationOptions.Files |
+            Alphaleonis.Win32.Filesystem.DirectoryEnumerationOptions.Recursive |
+            Alphaleonis.Win32.Filesystem.DirectoryEnumerationOptions.SkipReparsePoints |
+            Alphaleonis.Win32.Filesystem.DirectoryEnumerationOptions.ContinueOnException |
+            Alphaleonis.Win32.Filesystem.DirectoryEnumerationOptions.BasicSearch;
+
+        return Alphaleonis.Win32.Filesystem.Directory.EnumerateFileSystemEntries(dir, options, filters);
+    }
+
+    private static Stream OpenAdsStream(string streamFullPath)
+    {
+        return Alphaleonis.Win32.Filesystem.File.Open(streamFullPath, FileMode.Open, FileAccess.Read,
+            FileShare.Read, Alphaleonis.Win32.Filesystem.PathFormat.LongFullPath);
+    }
+
+
     public sealed class CsvOutTl
     {
         public string RunTime { get; set; }

--- a/PECmd/Program.cs
+++ b/PECmd/Program.cs
@@ -356,7 +356,20 @@ internal class Program
         {
             try
             {
-                var pf = LoadFile(f, q, ActiveDateTimeFormat);
+                IPrefetch pf;
+
+                //When scanning for prefetch hidden in alternate data streams, the carrier file's
+                //primary stream is often empty (e.g. a Prefetch entry created for an ADS-executed
+                //binary). Don't try to parse an empty primary stream as a prefetch - just scan its ADS
+                if (ads && new FileInfo(f).Length == 0)
+                {
+                    Log.Debug("{F} has an empty primary data stream; skipping direct parse and scanning alternate data streams only",f);
+                    pf = null;
+                }
+                else
+                {
+                    pf = LoadFile(f, q, ActiveDateTimeFormat);
+                }
 
                 if (pf != null)
                 {

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
      
              vss             Process all Volume Shadow Copies that exist on drive specified by -f or -d . Default is FALSE
              dedupe          Deduplicate -f or -d & VSCs based on SHA-1. First file found wins. Default is TRUE
+             ads             Scan alternate data streams of every file under -d (or the -f file) and parse any prefetch data hidden in them. Default is FALSE
 
              debug           Show debug information during processing
              trace           Show trace information during processing

--- a/README.md
+++ b/README.md
@@ -33,8 +33,28 @@
                PECmd.exe -d "C:\Temp" -k "system32, fonts"
                PECmd.exe -d "C:\Temp" --csv "c:\temp" --csvf foo.csv --json c:\temp\json
                PECmd.exe -d "C:\Windows\Prefetch"
+               PECmd.exe -d "C:\Windows\Prefetch" --ads --csv "c:\temp"
 
                Short options (single letter) are prefixed with a single dash. Long commands are prefixed with two dashes
+
+## Alternate Data Stream (ADS) scanning
+
+Use `--ads` to scan the NTFS alternate data streams of files for prefetch data hidden inside them.
+
+When an executable is run from an alternate data stream (for example `notepad.exe` stored as `host.txt:np.exe`), Windows records a prefetch entry whose carrier file has an empty primary stream and the real prefetch tucked into an ADS, e.g. `C:\Windows\Prefetch\HOST.TXT:NP.EXE-F3E0231A.pf`. A normal prefetch scan never looks inside streams, so these are missed. `--ads` finds and parses them.
+
+Behavior:
+
+- `--ads` is opt-in and off by default; without it, PECmd behaves exactly as before.
+- With `-d`, every file under the directory is checked (not just `.pf` files), and any stream that parses as a valid prefetch is reported.
+- With `-f`, the given file's own alternate data streams are scanned.
+- Detection is content based: each stream is parsed as prefetch, so a hidden prefetch is found regardless of the stream's name. Streams that are not prefetch (such as `Zone.Identifier`) are ignored.
+- Prefetch recovered from a stream is flagged in the CSV `Note` column as `Prefetch found in ADS`.
+- An alternate data stream has no timestamps of its own, so the source Created/Modified/Accessed values shown for an ADS-hosted prefetch are those of the carrier (host) file, which the stream inherits.
+
+Example:
+
+    PECmd.exe -d "C:\Windows\Prefetch" --ads --csv "c:\temp"
 
 ## Documentation
 


### PR DESCRIPTION
## What
Adds an opt-in `--ads` flag that scans NTFS alternate data streams for prefetch data hidden inside them.

- `-d <dir>`: recursively checks every file's streams, not just `.pf` files
- `-f <file>`: checks the target file's own streams
- Honors `--vss` (scans shadow-copy equivalents too)
- Off by default — behavior is unchanged without the flag

## Why
When a binary runs from an ADS (e.g. `notepad.exe` stored as `host.txt:np.exe`), Windows writes a prefetch entry whose carrier file has an empty primary stream, with the real `.pf` data hidden in an alternate stream (e.g. `HOST.TXT:NP.EXE-F3E0231A.pf`). A normal scan never looks inside streams, so these are missed entirely. Detection here is content-based (every stream is attempted with `PrefetchFile.Open`), so it finds hidden prefetch regardless of the stream name.

## Implementation notes
- Dedupe guard on `SourceFilename` avoids double-reporting against the existing built-in `.pf`-ADS handling
- AlphaFS directory enumeration is net472-only, so `EnumerateAllFiles` splits on `NET9_0_OR_GREATER` the same way the rest of the codebase already does
- .NET Framework can't stat a `host:stream` path, so source timestamps for ADS-recovered prefetch fall back to the carrier file's timestamps (which the stream inherits)
- ADS-recovered entries are flagged `Prefetch found in ADS` in the CSV `Note` column

## Known limitation
`--dedupe` hashes are tracked separately for the normal `-d` scan vs. the `--ads` scan, so with `--ads --vss --dedupe` an identical hidden prefetch present in the live directory and multiple shadow copies may be reported more than once. Happy to fix if that's worth addressing before merge — flagging it here in the meantime.